### PR TITLE
UNOMI-107 : Add a tag to distinct autocompleted properties.

### DIFF
--- a/services/src/main/resources/META-INF/cxs/tags/autocompleted.json
+++ b/services/src/main/resources/META-INF/cxs/tags/autocompleted.json
@@ -1,0 +1,4 @@
+{
+  "id": "autocompleted",
+  "parent": "profileTags"
+}


### PR DESCRIPTION
Hello, 
This commit is made to add "autocompleted" tag in Unomi tag list.
This tag will be used to distinct autocompleted properties and is made to Fix Unomi-107