### PR TITLE
pastEventCondition hardcoded 5000 limit/UNOMI-119

### DIFF
--- a/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
+++ b/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
@@ -145,6 +145,8 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
     private String minimalElasticSearchVersion = "5.0.0";
     private String maximalElasticSearchVersion = "5.3.0";
 
+    private String aggregateQueryBucketSize = "5000";
+
     private Map<String, Map<String, Map<String, Object>>> knownMappings = new HashMap<>();
 
     public void setBundleContext(BundleContext bundleContext) {
@@ -238,6 +240,10 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
 
     public void setMaximalElasticSearchVersion(String maximalElasticSearchVersion) {
         this.maximalElasticSearchVersion = maximalElasticSearchVersion;
+    }
+
+    public void setAggregateQueryBucketSize(String aggregateQueryBucketSize) {
+        this.aggregateQueryBucketSize = aggregateQueryBucketSize;
     }
 
     public void start() throws Exception {
@@ -1482,7 +1488,7 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
                         fieldName = getPropertyNameWithData(fieldName, itemType);
                         //default
                         if (fieldName != null) {
-                            bucketsAggregation = AggregationBuilders.terms("buckets").field(fieldName).size(5000);
+                            bucketsAggregation = AggregationBuilders.terms("buckets").field(fieldName).size(Integer.parseInt(aggregateQueryBucketSize));
                         } else {
                             // field name could be null if no existing data exists
                         }

--- a/persistence-elasticsearch/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/persistence-elasticsearch/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -49,6 +49,8 @@
             <cm:property name="minimalElasticSearchVersion" value="5.0.0" />
             <cm:property name="maximalElasticSearchVersion" value="5.3.0" />
 
+            <cm:property name="aggregateQuerybucketSize" value="5000" />
+
         </cm:default-properties>
     </cm:property-placeholder>
 
@@ -105,6 +107,8 @@
 
         <property name="minimalElasticSearchVersion" value="${es.minimalElasticSearchVersion}" />
         <property name="maximalElasticSearchVersion" value="${es.maximalElasticSearchVersion}" />
+
+        <property name="aggregateQueryBucketSize" value="${es.aggregateQueryBucketSize}" />
     </bean>
 
     <!-- We use a listener here because using the list directly for listening to proxies coming from the same bundle didn't seem to work -->

--- a/persistence-elasticsearch/core/src/main/resources/org.apache.unomi.persistence.elasticsearch.cfg
+++ b/persistence-elasticsearch/core/src/main/resources/org.apache.unomi.persistence.elasticsearch.cfg
@@ -43,3 +43,6 @@ bulkProcessor.backoffPolicy=exponential
 #   minimalElasticSearchVersion <= ElasticSearch node version < maximalElasticSearchVersion
 minimalElasticSearchVersion=5.0.0
 maximalElasticSearchVersion=5.3.0
+
+# The following setting is used to set the aggregate query bucket size
+aggregateQueryBucketSize=5000


### PR DESCRIPTION
Added the aggregateQueryBucketSize config to etc/org.apache.unomi.elasticsearch.cfg with a default value of 5000.

This config allows the user to increase the aggregate query bucket size when 5000 is not sufficient.