### PR TITLE
UNOMI-152 Fix monthly index New Year's bug

### DIFF
--- a/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
+++ b/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
@@ -506,7 +506,7 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
     }
 
     private String getMonthlyIndexName(Date date) {
-        String d = new SimpleDateFormat("-YYYY-MM").format(date);
+        String d = new SimpleDateFormat("-yyyy-MM").format(date);
         String monthlyIndexName = indexName + d;
         return monthlyIndexName;
     }


### PR DESCRIPTION
When formatting the date around new year's day, retrieving WEEK_YEAR can
yield next year or previous year as result. We should simply use YEAR.

More details: https://stackoverflow.com/questions/8686331/y-returns-2012-while-y-returns-2011-in-simpledateformat