### PR TITLE
UNOMI-168 Fix property type IT

### DIFF
--- a/itests/src/test/java/org/apache/unomi/itests/ProfileImportSurfersIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/ProfileImportSurfersIT.java
@@ -69,14 +69,11 @@ public class ProfileImportSurfersIT extends BaseIT {
         profileService.setPropertyType(propertyType);
 
         //Wait for data to be processed
-        Thread.sleep(1000);
+        Thread.sleep(10000);
 
         PropertyType propAlive = profileService.getPropertyType("alive");
 
         Assert.assertNotNull(propAlive);
-
-        //Wait for data to be processed
-        Thread.sleep(5000);
 
         /*** Surfers Test ***/
         ImportConfiguration importConfigSurfers = new ImportConfiguration();


### PR DESCRIPTION
Now we retrieve property types from DB every 5 seconds
(see 681384714130e49d747c163c5c3ac70774263e59), so we need longer waits
when running integration tests.