### PR TITLE
UNOMI-169 Run integration tests before deployment

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -99,6 +99,14 @@
             <type>xml</type>
             <scope>runtime</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.unomi</groupId>
+            <artifactId>unomi-itests</artifactId>
+            <version>1.3.0-incubating-SNAPSHOT</version>
+            <classifier>features</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
To achieve this I introduced a dependency of package module on itests
module. It does not build if integration-tests profile is not activated.