### PR TITLE
UNOMI-179 Event Persistence Non-transient

### DIFF
--- a/api/src/main/java/org/apache/unomi/api/Event.java
+++ b/api/src/main/java/org/apache/unomi/api/Event.java
@@ -113,6 +113,7 @@ public class Event extends Item implements TimestampedItem {
      * @param target     the target of the event if any
      * @param timestamp  the timestamp associated with the event if provided
      * @param properties the properties for this event if any
+     * @param persistent specifies if the event needs to be persisted
      */
     public Event(String eventType, Session session, Profile profile, String scope, Item source, Item target, Map<String, Object> properties, Date timestamp, boolean persistent) {
         this(eventType, session, profile, scope, source, target, timestamp);

--- a/api/src/main/java/org/apache/unomi/api/Event.java
+++ b/api/src/main/java/org/apache/unomi/api/Event.java
@@ -61,7 +61,7 @@ public class Event extends Item implements TimestampedItem {
     private Item source;
     private Item target;
 
-    private transient boolean persistent = true;
+    private boolean persistent = true;
 
     private transient Map<String, Object> attributes = new LinkedHashMap<>();
 
@@ -114,8 +114,9 @@ public class Event extends Item implements TimestampedItem {
      * @param timestamp  the timestamp associated with the event if provided
      * @param properties the properties for this event if any
      */
-    public Event(String eventType, Session session, Profile profile, String scope, Item source, Item target, Map<String, Object> properties, Date timestamp) {
+    public Event(String eventType, Session session, Profile profile, String scope, Item source, Item target, Map<String, Object> properties, Date timestamp, boolean persistent) {
         this(eventType, session, profile, scope, source, target, timestamp);
+        this.persistent = persistent;
         if (properties != null) {
             this.properties = properties;
         }
@@ -205,7 +206,6 @@ public class Event extends Item implements TimestampedItem {
      *
      * @return {@code true} if this Event needs to be persisted, {@code false} otherwise
      */
-    @XmlTransient
     public boolean isPersistent() {
         return persistent;
     }

--- a/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ESEventMixIn.java
+++ b/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ESEventMixIn.java
@@ -16,30 +16,14 @@
  */
 package org.apache.unomi.persistence.elasticsearch;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.unomi.api.Event;
-import org.apache.unomi.api.Item;
-import org.apache.unomi.persistence.spi.CustomObjectMapper;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
- * This CustomObjectMapper is used to avoid the version parameter to be registered in ES
- * @author dgaillard
+ * This mixin is used in ESCustomObjectMapper to prevent the persistent parameter from being registered in ES
  */
-public class ESCustomObjectMapper extends CustomObjectMapper {
+public abstract class ESEventMixIn {
 
-    private static final long serialVersionUID = -5017620674440085575L;
+    public ESEventMixIn() { }
 
-    public ESCustomObjectMapper() {
-        super();
-        this.addMixIn(Item.class, ESItemMixIn.class);
-        this.addMixIn(Event.class, ESEventMixIn.class);
-    }
-
-    public static ObjectMapper getObjectMapper() {
-        return ESCustomObjectMapper.Holder.INSTANCE;
-    }
-
-    private static class Holder {
-        static final ESCustomObjectMapper INSTANCE = new ESCustomObjectMapper();
-    }
+    @JsonIgnore abstract boolean isPersistent();
 }

--- a/wab/src/main/java/org/apache/unomi/web/ContextServlet.java
+++ b/wab/src/main/java/org/apache/unomi/web/ContextServlet.java
@@ -323,7 +323,8 @@ public class ContextServlet extends HttpServlet {
             for (Event event : contextRequest.getEvents()){
                 if(event.getEventType() != null) {
                     Profile sessionProfile = session.getProfile();
-                    Event eventToSend = new Event(event.getEventType(), session, sessionProfile, contextRequest.getSource().getScope(), event.getSource(), event.getTarget(), event.getProperties(), timestamp);
+                    Event eventToSend = new Event(event.getEventType(), session, sessionProfile, contextRequest.getSource().getScope(),
+                            event.getSource(), event.getTarget(), event.getProperties(), timestamp, event.isPersistent());
                     if (!eventService.isEventAllowed(event, thirdPartyId)) {
                         logger.debug("Event is not allowed : {}", event.getEventType());
                         continue;

--- a/wab/src/main/java/org/apache/unomi/web/EventsCollectorServlet.java
+++ b/wab/src/main/java/org/apache/unomi/web/EventsCollectorServlet.java
@@ -184,7 +184,8 @@ public class EventsCollectorServlet extends HttpServlet {
 
         for (Event event : events.getEvents()){
             if(event.getEventType() != null){
-                Event eventToSend = new Event(event.getEventType(), session, profile, event.getScope(), event.getSource(), event.getTarget(), event.getProperties(), timestamp);
+                Event eventToSend = new Event(event.getEventType(), session, profile, event.getScope(), event.getSource(),
+                        event.getTarget(), event.getProperties(), timestamp, event.isPersistent());
                 if (sessionProfile.isAnonymousProfile()) {
                     // Do not keep track of profile in event
                     eventToSend.setProfileId(null);


### PR DESCRIPTION
Changed the persistence field to be non-transient in the Event class.
Used ESEventMixIn to prevent that value from being saved in ES.  Updated
the Event constructor to accept persistent.

This feature allows the user to pass "persistent": false with their
events if the intent is only to trigger a rule / action downstream.

If "persistent" is not set it defaults to true.