### PR TITLE
Update generation of documentation script

### DIFF
--- a/generate-site-and-upload.sh
+++ b/generate-site-and-upload.sh
@@ -22,11 +22,22 @@ if [ $# -ne 2 ]
     echo "Illegal number of arguments supplied. Syntax should be generate-site-and-upload.sh SVNusername SVNpassword"
     exit 1
 fi
-echo Generating site...
-mvn clean install site site:stage -P !integration-tests,!performance-tests
+echo Generating documentation...
+mvn clean
+cd manual
+mvn -Phtml
+mvn -Ppdf
+cd ..
 cd rest
+mvn javadoc:aggregate
 mvn package
-cd -
-echo Committing site to Apache SVN...
-mvn scm-publish:publish-scm -Dusername=$1 -Dpassword=$2
-echo Site generation and upload completed.
+cd ..
+mkdir target/staging/unomi-api
+cp -R rest/target/site/apidocs target/staging/unomi-api
+mkdir target/staging/manual
+cp -R manual/target/generated-html/latest target/staging/manual
+echo Committing documentation to Apache SVN...
+mvn scm-publish:publish-scm -Dscmpublish.pubScmUrl=scm:svn:https://svn.apache.org/repos/asf/incubator/unomi/website/manual -Dscmpublish.content=target/staging/manual -Dusername=$1 -Dpassword=$2
+mvn scm-publish:publish-scm -Dscmpublish.pubScmUrl=scm:svn:https://svn.apache.org/repos/asf/incubator/unomi/website/unomi-api -Dscmpublish.content=target/staging/unomi-api -Dusername=$1 -Dpassword=$2
+mvn scm-publish:publish-scm -Dscmpublish.pubScmUrl=scm:svn:https://svn.apache.org/repos/asf/incubator/unomi/website/rest-api-doc -Dscmpublish.content=target/staging/rest-api-doc -Dusername=$1 -Dpassword=$2
+echo Documentation generation and upload completed.

--- a/generate-site.sh
+++ b/generate-site.sh
@@ -17,8 +17,18 @@
 #    limitations under the License.
 #
 ################################################################################
-echo Generating site...
-mvn site site:stage -P !integration-tests,!performance-tests
+echo Generating documentation...
+mvn clean
+cd manual
+mvn -Phtml
+mvn -Ppdf
+cd ..
 cd rest
+mvn javadoc:aggregate
 mvn package
-cd -
+cd ..
+mkdir target/staging/unomi-api
+cp -R rest/target/site/apidocs target/staging/unomi-api
+mkdir target/staging/manual
+cp -R manual/target/generated-html/latest target/staging/manual
+echo Documentation generation completed!

--- a/manual/pom.xml
+++ b/manual/pom.xml
@@ -61,7 +61,7 @@
                         </executions>
                         <configuration>
                             <sourceDirectory>src/main/asciidoc</sourceDirectory>
-                            <outputDirectory>target/generated-html/${project.version}</outputDirectory>
+                            <outputDirectory>target/generated-html/latest</outputDirectory>
                             <preserveDirectories>true</preserveDirectories>
                             <headerFooter>true</headerFooter>
                             <imagesDir>src/main/asciidoc/images</imagesDir>
@@ -89,7 +89,7 @@
                         </dependencies>
                         <configuration>
                             <sourceDirectory>src/main/asciidoc</sourceDirectory>
-                            <outputDirectory>target/generated-pdf/${project.version}</outputDirectory>
+                            <outputDirectory>target/generated-pdf/latest</outputDirectory>
                             <preserveDirectories>true</preserveDirectories>
                             <headerFooter>true</headerFooter>
                             <backend>pdf</backend>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -234,11 +234,6 @@
                     </analysis>
                 </configuration>
             </plugin>
-        </plugins>
-    </build>
-
-    <reporting>
-        <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -273,6 +268,5 @@
                 </configuration>
             </plugin>
         </plugins>
-    </reporting>
-
+    </build>
 </project>


### PR DESCRIPTION
Use the `generate-site.sh` to generate all the documentation (rest-api-doc, api-javadoc, manual).

The output is located under `target/staging`